### PR TITLE
Proposing some additions to this list.

### DIFF
--- a/tutorials/hosting-specific/tutorials-en.md
+++ b/tutorials/hosting-specific/tutorials-en.md
@@ -17,6 +17,8 @@ This is a list of links with tutorials on how to upgrade the PHP version on a sp
 * [Fasthosts](https://help.fasthosts.co.uk/app/answers/detail/a_id/1962/~/changing-your-php-version)
 * [GoDaddy (Web & Classic Hosting)](https://www.godaddy.com/help/view-or-change-your-php-version-3937)
 * [GoDaddy (Linux cPanel Hosting)](https://www.godaddy.com/help/view-or-change-your-php-version-16090)
+* [Google Cloud (Compute Engine)] (SOURCE NEEDED)
+* [Google Cloud (App Engine)] (https://cloud.google.com/appengine/docs/standard/php7/php-differences)
 * [GreenGeeks](https://www.greengeeks.com/kb/1838/what-version-of-php-does-greengeeks-use/)
 * [Hetzner](https://hetzner.co.za/help-centre/website/how-do-i-upgradedowngrade-my-version-of-php/)
 * [HostGator](https://www.hostgator.com/help/article/php-configuration-plugin)


### PR DESCRIPTION
I would provide a source for the google cloud compute engine if I had one, however, the best I have been able to come up with is googles documentation for the app engine. I have yet to find a reputable source for the compute engine. Possibly, we could consider adding some php upgrade info for server specific environments (ie. apache/debian/etc.).

What are everyone's thoughts on adding server based upgrade information? I would like to see this, for many reasons, I believe encouraging hosting from the cloud is becoming more popular and by including this on the list it will help those who need the help and also provide a more dynamic list in general.